### PR TITLE
Change duration_secs to f64 to allow for floating and negative values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ fn main() {
     // Create a multimedia playlist, including the duration in seconds and name for each entry.
     let playlist = vec![
         m3u::path_entry(r"C:\Documents and Settings\I\My Music\Sample.mp3")
-            .extend(123, "Sample artist - Sample title"),
+            .extend(123.0, "Sample artist - Sample title"),
         m3u::path_entry(r"C:\Documents and Settings\I\My Music\Greatest Hits\Example.ogg")
-            .extend(321, "Example Artist - Example title"),
+            .extend(321.0, "Example Artist - Example title"),
         m3u::path_entry(r"Sample.mp3")
-            .extend(123, "Sample artist - Sample title"),
+            .extend(123.0, "Sample artist - Sample title"),
         m3u::path_entry(r"Greatest Hits\Example.ogg")
-            .extend(321, "Example Artist - Example title"),
+            .extend(321.0, "Example Artist - Example title"),
     ];
 
     // Write the playlist to the file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use url::Url;
 ///
 /// In rare cases an `Entry` may point to another `.m3u` file. If a user wishes to support this in
 /// their application, they must be sure to handle cycles within the **M3U** graph.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 pub enum Entry {
     /// The entry resides at the given `Path`.
     ///
@@ -37,7 +37,7 @@ pub enum Entry {
 }
 
 /// An entry with some associated extra information.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EntryExt {
     /// The M3U entry. Can be either a `Path` or `Url`.
     pub entry: Entry,
@@ -46,10 +46,12 @@ pub struct EntryExt {
 }
 
 /// Extra information associated with an M3U entry.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ExtInf {
     /// The duration of the media's runtime in seconds.
-    pub duration_secs: u64,
+    ///
+    /// Note that some `m3u` extended formats specify streams with a `-1` duration.
+    pub duration_secs: f64,
     /// The name of the media. E.g. "Aphex Twin - Windowlicker".
     pub name: String,
 }
@@ -74,7 +76,7 @@ impl Entry {
     }
 
     /// Extend the entry with extra information including the duration in seconds and a name.
-    pub fn extend<N>(self, duration_secs: u64, name: N) -> EntryExt
+    pub fn extend<N>(self, duration_secs: f64, name: N) -> EntryExt
         where N: Into<String>,
     {
         EntryExt {

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -27,13 +27,13 @@ fn mixed() {
 fn ext() {
     let expected = vec![
         m3u::path_entry(r"C:\Documents and Settings\I\My Music\Sample.mp3")
-            .extend(123, "Sample artist - Sample title"),
+            .extend(123.0, "Sample artist - Sample title"),
         m3u::path_entry(r"C:\Documents and Settings\I\My Music\Greatest Hits\Example.ogg")
-            .extend(321, "Example Artist - Example title"),
+            .extend(321.0, "Example Artist - Example title"),
         m3u::path_entry(r"Sample.mp3")
-            .extend(123, "Sample artist - Sample title"),
+            .extend(123.0, "Sample artist - Sample title"),
         m3u::path_entry(r"Greatest Hits\Example.ogg")
-            .extend(321, "Example Artist - Example title"),
+            .extend(321.0, "Example Artist - Example title"),
     ];
 
     let path = std::path::Path::new("tests/ext.m3u");

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -46,13 +46,13 @@ fn entry_ext() {
     // Create a multimedia playlist, including the duration in seconds and name for each entry.
     let playlist = vec![
         m3u::path_entry(r"C:\Documents and Settings\I\My Music\Sample.mp3")
-            .extend(123, "Sample artist - Sample title"),
+            .extend(123.0, "Sample artist - Sample title"),
         m3u::path_entry(r"C:\Documents and Settings\I\My Music\Greatest Hits\Example.ogg")
-            .extend(321, "Example Artist - Example title"),
+            .extend(321.0, "Example Artist - Example title"),
         m3u::path_entry(r"Sample.mp3")
-            .extend(123, "Sample artist - Sample title"),
+            .extend(123.0, "Sample artist - Sample title"),
         m3u::path_entry(r"Greatest Hits\Example.ogg")
-            .extend(321, "Example Artist - Example title"),
+            .extend(321.0, "Example Artist - Example title"),
     ];
 
     const FILEPATH: &'static str = "tests/playlist_ext.m3u";


### PR DESCRIPTION
Closes #3 - I decided against interpreting `-1` as a stream as this may not be the case for all implementations of M3U and there's no need to back ourselves into a corner in this case as the user can just as easily manually check the `f64` for `-1` by casting it.