### PR TITLE
Replace owned inner BufWrite with a mutable reference to it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "m3u"
 description = "A crate for reading and writing `.m3u` files - the de facto standard for multimedia playlists."
-version = "1.0.0"
+version = "1.0.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["m3u", "playlist", "multimedia", "music", "audio"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 //! There is no formal specification for the **M3U** format. This crate is implemented based on the
 //! rough description under the format's current wikipedia entry.
 
-#![warn(missing_docs)]
-
 pub extern crate url;
 
 mod read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,5 +94,5 @@ pub fn path_entry<P>(path: P) -> Entry
 
 /// A helper function to simplify creation of the `Entry`'s `Url` variant.
 pub fn url_entry(url: &str) -> Result<Entry, url::ParseError> {
-    Url::parse(url).map(|url| Entry::Url(url))
+    Url::parse(url).map(Entry::Url)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,10 @@ impl Entry {
         where N: Into<String>,
     {
         EntryExt {
-            extinf: ExtInf { duration_secs: duration_secs, name: name.into() },
+            extinf: ExtInf {
+                duration_secs,
+                name: name.into(),
+            },
             entry: self,
         }
     }

--- a/src/read.rs
+++ b/src/read.rs
@@ -135,7 +135,7 @@ impl<R> EntryExtReader<R>
             let line = line_buffer.trim_left();
 
             // The first line of the extended M3U format should always be the "#EXTM3U" header.
-            const HEADER: &'static str = "#EXTM3U";
+            const HEADER: &str = "#EXTM3U";
             if line.len() >= HEADER.len() && &line[..HEADER.len()] == HEADER {
                 break;
             }
@@ -165,7 +165,7 @@ impl<R> EntryExtReader<R>
     fn read_next_entry(&mut self) -> Result<Option<EntryExt>, ReadEntryExtError> {
         let Reader { ref mut reader, ref mut line_buffer, .. } = *self;
 
-        const TAG: &'static str = "#EXTINF:";
+        const TAG: &str = "#EXTINF:";
 
         // Read an `ExtInf` from the given line.
         //

--- a/src/read.rs
+++ b/src/read.rs
@@ -131,8 +131,8 @@ impl<R> EntryExtReader<R>
         let mut line_buffer = String::new();
 
         loop {
-            let num_read_bytes = try!(reader.read_line(&mut line_buffer));
             let line = line_buffer.trim_left();
+            let num_read_bytes = reader.read_line(&mut line_buffer)?;
 
             // The first line of the extended M3U format should always be the "#EXTM3U" header.
             const HEADER: &str = "#EXTM3U";
@@ -195,7 +195,7 @@ impl<R> EntryExtReader<R>
         loop {
             // Read the next line or return `None` if we're done.
             line_buffer.clear();
-            if try!(reader.read_line(line_buffer)) == 0 {
+            if reader.read_line(line_buffer)? == 0 {
                 return Ok(None);
             }
 
@@ -223,7 +223,7 @@ impl<R> EntryExtReader<R>
             };
 
             // Read the next non-empty, non-comment line as an entry.
-            let entry = match try!(read_next_entry(reader, line_buffer)) {
+            let entry = match read_next_entry(reader, line_buffer)? {
                 None => return Ok(None),
                 Some(entry) => entry,
             };
@@ -253,7 +253,7 @@ impl EntryReader<std::io::BufReader<std::fs::File>> {
     pub fn open<P>(filename: P) -> Result<Self, std::io::Error>
         where P: AsRef<std::path::Path>,
     {
-        let file = try!(std::fs::File::open(filename));
+        let file = std::fs::File::open(filename)?;
         let buf_reader = std::io::BufReader::new(file);
         Ok(Self::new(buf_reader))
     }
@@ -269,7 +269,7 @@ impl EntryExtReader<std::io::BufReader<std::fs::File>> {
     pub fn open_ext<P>(filename: P) -> Result<Self, EntryExtReaderConstructionError>
         where P: AsRef<std::path::Path>,
     {
-        let file = try!(std::fs::File::open(filename));
+        let file = std::fs::File::open(filename)?;
         let buf_reader = std::io::BufReader::new(file);
         Self::new_ext(buf_reader)
     }
@@ -284,7 +284,7 @@ fn read_next_entry<R>(reader: &mut R, line_buffer: &mut String) -> Result<Option
     loop {
         // Read the next line or return `None` if we're done.
         line_buffer.clear();
-        if try!(reader.read_line(line_buffer)) == 0 {
+        if reader.read_line(line_buffer)? == 0 {
             return Ok(None);
         }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -355,17 +355,8 @@ impl From<std::io::Error> for ReadEntryExtError {
     }
 }
 
-
 impl std::error::Error for EntryExtReaderConstructionError {
-    fn description(&self) -> &str {
-        match *self {
-            EntryExtReaderConstructionError::HeaderNotFound =>
-                "the \"#EXTM3U\" header was not found",
-            EntryExtReaderConstructionError::BufRead(ref err) =>
-                std::error::Error::description(err),
-        }
-    }
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             EntryExtReaderConstructionError::HeaderNotFound => None,
             EntryExtReaderConstructionError::BufRead(ref err) => Some(err),
@@ -374,15 +365,7 @@ impl std::error::Error for EntryExtReaderConstructionError {
 }
 
 impl std::error::Error for ReadEntryExtError {
-    fn description(&self) -> &str {
-        match *self {
-            ReadEntryExtError::ExtInfNotFound(_) =>
-                "the \"#EXTINF:\" tag was not found or was incorrectly formatted",
-            ReadEntryExtError::BufRead(ref err) =>
-                std::error::Error::description(err),
-        }
-    }
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             ReadEntryExtError::ExtInfNotFound(_) => None,
             ReadEntryExtError::BufRead(ref err) => Some(err),
@@ -390,14 +373,14 @@ impl std::error::Error for ReadEntryExtError {
     }
 }
 
-
 impl std::fmt::Display for EntryExtReaderConstructionError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match *self {
-            EntryExtReaderConstructionError::HeaderNotFound =>
-                write!(f, "{}", std::error::Error::description(self)),
-            EntryExtReaderConstructionError::BufRead(ref err) =>
-                err.fmt(f),
+            EntryExtReaderConstructionError::HeaderNotFound => {
+                write!(f, "the \"#EXTM3U\" header was not found")
+            }
+
+            EntryExtReaderConstructionError::BufRead(ref err) => err.fmt(f),
         }
     }
 }
@@ -405,10 +388,13 @@ impl std::fmt::Display for EntryExtReaderConstructionError {
 impl std::fmt::Display for ReadEntryExtError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match *self {
-            ReadEntryExtError::ExtInfNotFound(_) =>
-                write!(f, "{}", std::error::Error::description(self)),
-            ReadEntryExtError::BufRead(ref err) =>
-                err.fmt(f),
+            ReadEntryExtError::ExtInfNotFound(_) => {
+                write!(
+                    f,
+                    "the \"#EXTINF:\" tag was not found or was incorrectly formatted"
+                )
+            }
+            ReadEntryExtError::BufRead(ref err) => err.fmt(f),
         }
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -131,8 +131,8 @@ impl<R> EntryExtReader<R>
         let mut line_buffer = String::new();
 
         loop {
-            let line = line_buffer.trim_left();
             let num_read_bytes = reader.read_line(&mut line_buffer)?;
+            let line = line_buffer.trim_start();
 
             // The first line of the extended M3U format should always be the "#EXTM3U" header.
             const HEADER: &str = "#EXTM3U";
@@ -200,7 +200,7 @@ impl<R> EntryExtReader<R>
             }
 
             let extinf = {
-                let line = line_buffer.trim_left();
+                let line = line_buffer.trim_start();
 
                 match line.chars().next() {
                     // Skip empty lines.
@@ -216,7 +216,7 @@ impl<R> EntryExtReader<R>
                     // Due to the lack of official specification, it is unclear whether a mixture
                     // of tagged and non-tagged entries should be supported for the EXTM3U format.
                     Some(_) => {
-                        let entry = read_entry(line.trim_right());
+                        let entry = read_entry(line.trim_end());
                         return Err(ReadEntryExtError::ExtInfNotFound(entry));
                     },
                 }
@@ -288,14 +288,14 @@ fn read_next_entry<R>(reader: &mut R, line_buffer: &mut String) -> Result<Option
             return Ok(None);
         }
 
-        let line = line_buffer.trim_left();
+        let line = line_buffer.trim_start();
         match line.chars().next() {
             // Skip empty lines.
             None => continue,
             // Skip comments.
             Some('#') => continue,
             // Break when we have a non-empty, non-comment line.
-            _ => return Ok(Some(read_entry(line.trim_right()))),
+            _ => return Ok(Some(read_entry(line.trim_end()))),
         }
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -11,6 +11,7 @@ use url;
 /// and entries are each read from a single line of plain text.
 ///
 /// A `Reader` will only attempt to read entries of type `E`.
+#[derive(Debug, Clone)]
 pub struct Reader<R, E>
     where R: std::io::BufRead,
 {
@@ -39,6 +40,7 @@ pub struct Entries<'r, R>
 /// An iterator that yields `EntryExt`s.
 ///
 /// All `EntryExt`s are lazily read from the inner buffered reader.
+#[derive(Debug)]
 pub struct EntryExts<'r, R>
     where R: 'r + std::io::BufRead,
 {

--- a/src/read.rs
+++ b/src/read.rs
@@ -76,8 +76,8 @@ impl<R, E> Reader<R, E>
 
     fn new_inner(reader: R, line_buffer: String) -> Self {
         Reader {
-            reader: reader,
-            line_buffer: line_buffer,
+            reader,
+            line_buffer,
             entry: std::marker::PhantomData,
         }
     }
@@ -186,8 +186,8 @@ impl<R> EntryExtReader<R>
             let name = parts.next().map(|s| s.trim().into()).unwrap_or_else(String::new);
 
             Some(ExtInf {
-                duration_secs: duration_secs,
-                name: name,
+                duration_secs,
+                name,
             })
         }
 
@@ -229,10 +229,7 @@ impl<R> EntryExtReader<R>
             };
 
             return match extinf {
-                Some(extinf) => Ok(Some(EntryExt {
-                    entry: entry,
-                    extinf: extinf,
-                })),
+                Some(extinf) => Ok(Some(EntryExt { entry, extinf })),
                 None => Err(ReadEntryExtError::ExtInfNotFound(entry)),
             }
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -61,7 +61,7 @@ impl<W> EntryWriter<W>
     pub fn write_entry(&mut self, entry: &Entry) -> Result<(), std::io::Error> {
         let Writer { ref mut writer, ref mut line_buffer, .. } = *self;
         line_buffer.clear();
-        try!(write_entry(line_buffer, entry));
+        write_entry(line_buffer, entry)?;
         writer.write_all(line_buffer)
     }
 
@@ -76,8 +76,8 @@ impl<W> EntryExtWriter<W>
     /// The `#EXTM3U` header line is written immediately.
     pub fn new_ext(mut writer: W) -> Result<Self, std::io::Error> {
         let mut line_buffer = Vec::new();
-        try!(writeln!(&mut line_buffer, "#EXTM3U"));
-        try!(writer.write_all(&line_buffer));
+        writeln!(&mut line_buffer, "#EXTM3U")?;
+        writer.write_all(&line_buffer)?;
         Ok(Self::new_inner(writer, line_buffer))
     }
 
@@ -88,8 +88,12 @@ impl<W> EntryExtWriter<W>
         let Writer { ref mut writer, ref mut line_buffer, .. } = *self;
         line_buffer.clear();
         let extinf = &entry_ext.extinf;
-        try!(writeln!(line_buffer, "#EXTINF:{},{}", extinf.duration_secs, &extinf.name));
-        try!(write_entry(line_buffer, &entry_ext.entry));
+        writeln!(
+            line_buffer,
+            "#EXTINF:{},{}",
+            extinf.duration_secs, &extinf.name
+        )?;
+        write_entry(line_buffer, &entry_ext.entry)?;
         writer.write_all(line_buffer)
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -85,6 +85,17 @@ where
     /// Attempt to write the given `EntryExt` to the given `writer`.
     ///
     /// First writes the `#EXTINF:` line, then writes the entry line.
+    /// # Example
+    /// ```rust
+    /// let mut buff=std::io::Cursor::new(vec![]);
+    /// {
+    /// let mut writer=m3u::EntryExtWriter::new_ext(&mut buff).expect("Unable to open writer");
+    /// let entry = m3u::url_entry("http://server/stream.mp4").unwrap().extend(-1.0, "Channel 1");
+    /// writer.write_entry(&entry);
+    /// }
+    /// let result=std::str::from_utf8(buff.get_ref()).unwrap();
+    /// assert_eq!(result, "#EXTM3U\n#EXTINF:-1,Channel 1\nhttp://server/stream.mp4\n");
+    /// ```
     pub fn write_entry(&mut self, entry_ext: &EntryExt) -> Result<(), std::io::Error> {
         let Writer { ref mut writer, ref mut line_buffer, .. } = *self;
         line_buffer.clear();

--- a/src/write.rs
+++ b/src/write.rs
@@ -27,8 +27,8 @@ impl<W, E> Writer<W, E>
 
     fn new_inner(writer: W, line_buffer: Vec<u8>) -> Self {
         Writer {
-            writer: writer,
-            line_buffer: line_buffer,
+            writer,
+            line_buffer,
             entry: std::marker::PhantomData,
         }
     }


### PR DESCRIPTION
`Writer` struct owns a inner `BufWrite` implementation. This is OK to write to a file or to standard output, but is not suitable for in-memory `String`s (to write unit tests for example). In Rust ownership system, one should borrow a mutable reference to an external object instead of consuming it.